### PR TITLE
apim: rename service-level tag 'inference' → 'ai-gateway'

### DIFF
--- a/options-infra/modules/apim/common-apim-setup.bicep
+++ b/options-infra/modules/apim/common-apim-setup.bicep
@@ -186,7 +186,7 @@ module inferenceApi 'v2/inference-api.bicep' = {
 // Same per-model routing as the passthrough (shares the routing fragment), but
 // uses the AzureOpenAI OpenAPI spec so the APIM portal renders the test
 // console and SDK generators see per-operation definitions.
-// `dependsOn: [inferenceApi]` avoids the service-level `inference` tag race
+// `dependsOn: [inferenceApi]` avoids the service-level `ai-gateway` tag race
 // condition between concurrent API deployments.
 module inferenceApiSpec 'v2/inference-api-azure.bicep' = {
   name: 'inference-api-spec-deployment'
@@ -212,7 +212,7 @@ module inferenceApiSpec 'v2/inference-api-azure.bicep' = {
 // backend pools, so the onHandshake policy routes per-deployment to a concrete
 // wss backend (advanced/multi-foundry-backends is bypassed here). Reuses the
 // same inbound JWT validation as the HTTP APIs. Depends on inferenceApi to
-// avoid the service-level `inference` tag race condition.
+// avoid the service-level `ai-gateway` tag race condition.
 module realtimeApi 'v2/realtime-ws-api.bicep' = if (hasRealtime) {
   name: 'realtime-ws-api-deployment'
   dependsOn: [inferenceApi]

--- a/options-infra/modules/apim/v2/inference-api-azure.bicep
+++ b/options-infra/modules/apim/v2/inference-api-azure.bicep
@@ -71,18 +71,18 @@ resource api 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
   }
 }
 
-resource inferenceTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
-  name: 'inference'
+resource aiGatewayTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
+  name: 'ai-gateway'
   parent: apimService
   properties: {
-    displayName: 'inference'
+    displayName: 'AI Gateway'
   }
 }
 
-resource apiTag 'Microsoft.ApiManagement/service/apis/tags@2024-06-01-preview' = {
-  name: 'inference'
+resource aiGatewayApiTag 'Microsoft.ApiManagement/service/apis/tags@2024-06-01-preview' = {
+  name: 'ai-gateway'
   parent: api
-  dependsOn: [inferenceTag]
+  dependsOn: [aiGatewayTag]
 }
 
 resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-preview' = {

--- a/options-infra/modules/apim/v2/inference-api.bicep
+++ b/options-infra/modules/apim/v2/inference-api.bicep
@@ -157,18 +157,18 @@ resource api 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
   }
 }
 
-resource inferenceTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
-  name: 'inference'
+resource aiGatewayTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
+  name: 'ai-gateway'
   parent: apimService
   properties: {
-    displayName: 'inference'
+    displayName: 'AI Gateway'
   }
 }
 
-resource apiTag 'Microsoft.ApiManagement/service/apis/tags@2024-06-01-preview' = {
-  name: 'inference'
+resource aiGatewayApiTag 'Microsoft.ApiManagement/service/apis/tags@2024-06-01-preview' = {
+  name: 'ai-gateway'
   parent: api
-  dependsOn: [inferenceTag]
+  dependsOn: [aiGatewayTag]
 }
 // https://learn.microsoft.com/azure/templates/microsoft.apimanagement/service/apis/policies
 resource apiPolicy 'Microsoft.ApiManagement/service/apis/policies@2024-06-01-preview' = {

--- a/options-infra/modules/apim/v2/openai-api-v1.bicep
+++ b/options-infra/modules/apim/v2/openai-api-v1.bicep
@@ -72,20 +72,6 @@ resource api 'Microsoft.ApiManagement/service/apis@2024-06-01-preview' = {
   }
 }
 
-resource inferenceTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
-  name: 'inference'
-  parent: apimService
-  properties: {
-    displayName: 'inference'
-  }
-}
-
-resource apiTag 'Microsoft.ApiManagement/service/apis/tags@2024-06-01-preview' = {
-  name: 'inference'
-  parent: api
-  dependsOn: [inferenceTag]
-}
-
 resource aiGatewayTag 'Microsoft.ApiManagement/service/tags@2024-06-01-preview' = {
   name: 'ai-gateway'
   parent: apimService


### PR DESCRIPTION
## Summary

Rename the APIM service-level tag `inference` to `ai-gateway` in the three v2 API modules that were creating it, so a single umbrella tag surfaces every API this gateway exposes. This matches:
- The existing `ai-gateway` tag already created by `advanced/advanced-policies.bicep` (used to group the config-viewer API).
- The pre-existing `ai-gateway` tag block already in `v2/openai-api-v1.bicep` (which also had a duplicate `inference` tag, now removed).

## Changes

| File | Change |
|---|---|
| `v2/inference-api.bicep` | `inferenceTag` → `aiGatewayTag` (name `inference` → `ai-gateway`, displayName `inference` → `AI Gateway`). Same for the `apis/tags` association. |
| `v2/inference-api-azure.bicep` | Same rename as above. |
| `v2/openai-api-v1.bicep` | Drop the duplicate `inference` tag block; keep only the pre-existing `ai-gateway` block. |
| `common-apim-setup.bicep` | Update two race-condition comments to reference `ai-gateway` instead of `inference`. |

## Why

Downstream consumer (Komatsu AI Landing Zone) originally used `ai-gateway` throughout and the recent module refresh from this repo diverged the naming. Aligning on `ai-gateway` in one place (upstream) lets both trees converge.

## Non-goals / not a race concern

The existing `dependsOn` chain in `common-apim-setup.bicep` (`advancedPolicies` → `common_ai_gateway_setup` → `inferenceApi` → `inferenceApiSpec/realtimeApi/openaiV1Api`) already serializes tag creation. ARM upserts on identical tag properties, so having both `advanced-policies.bicep` and the v2 modules declare the same `ai-gateway` service-level tag is safe (as it already was for `openai-api-v1.bicep` pre-change).

## Test

- `az bicep build` passes on the referring templates.
- No ARM behavior change beyond the tag rename — resource IDs of the API objects and their policies are untouched.
